### PR TITLE
Check for empty OutputList. PumpCentrifugalClass returns an emtpy one...

### DIFF
--- a/Python27/ORCSim/ACHPTools.py
+++ b/Python27/ORCSim/ACHPTools.py
@@ -64,11 +64,14 @@ def Write2CSV(Class,filename,append=False):
         for item in dir(Class):
             #If the item has an outputList, collect it
             if hasattr(getattr(Class,item),'OutputList'):
-                head,units,vals=OL2Strings(getattr(Class,item).OutputList())
-                componentList+=[BuildComponentList(units,item)]
-                headList+=[head]
-                unitsList+=[units]
-                valsList+=[vals]
+                OL=getattr(Class,item).OutputList() 
+                #Unless it's empty
+		if OL != []:
+		    head,units,vals=OL2Strings(OL)
+		    componentList+=[BuildComponentList(units,item)]
+		    headList+=[head]
+		    unitsList+=[units]
+		    valsList+=[vals]
         components=','.join(componentList)
         head=','.join(headList)
         units=','.join(unitsList)

--- a/Python27/ORCSim/Cycle_solve.py
+++ b/Python27/ORCSim/Cycle_solve.py
@@ -193,7 +193,7 @@ def ORCSystem_Kortrijk(Inputs, run):
         Cycle.PreconditionedSolve_ORCRegen(Inputs)
         Cycle.ConvergencePlot()
         Cycle.BaselineTs_Celsius(Inputs)
-        #Write2CSV(Cycle,'ORC_Cycle.csv', append=run>0)
+        Write2CSV(Cycle,'ORC_Cycle.csv', append=run>0)
 
     print Cycle.OutputList()
 


### PR DESCRIPTION
Got an index out of range error in OL2Strings because PumpCentrifugalClass returns an empty OutputList. 